### PR TITLE
Upgrade to Godot 4.2.1

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -3,9 +3,6 @@ name: "build project"
 on: 
   push:
 
-env:
-  GODOT_VERSION: 4.2.1
-
 jobs:
   # job id, can be anything
   export_game:
@@ -31,8 +28,8 @@ jobs:
       uses: firebelley/godot-export@v5.2.1
       with:
         # Defining all the required inputs
-        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip
-        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz
+        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip
+        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_export_templates.tpz
         relative_project_path: ./
         export_debug: false
         archive_output: true

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -3,6 +3,9 @@ name: "build project"
 on: 
   push:
 
+env:
+  GODOT_VERSION: 4.2.1
+
 jobs:
   # job id, can be anything
   export_game:
@@ -28,8 +31,8 @@ jobs:
       uses: firebelley/godot-export@v5.2.1
       with:
         # Defining all the required inputs
-        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.2/Godot_v4.2-stable_linux.x86_64.zip
-        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.2/Godot_v4.2-stable_export_templates.tpz
+        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_linux.x86_64.zip
+        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_export_templates.tpz
         relative_project_path: ./
         export_debug: false
         archive_output: true

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -31,8 +31,8 @@ jobs:
       uses: firebelley/godot-export@v5.2.1
       with:
         # Defining all the required inputs
-        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_linux.x86_64.zip
-        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_export_templates.tpz
+        godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip
+        godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_export_templates.tpz
         relative_project_path: ./
         export_debug: false
         archive_output: true


### PR DESCRIPTION
Upgrade build workflow for Godot 4.2.1. No project files needed updating.